### PR TITLE
meson.build: new file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,1 @@
+project('prometheus-client-c')


### PR DESCRIPTION
Hi @acetcom,

while packaging open5gs for the Osmocom OBS, we run `meson subprojects download` to have the sources of subprojects in the source package, so we can later build the binary package without access to internet.

The command is currently failing with:
```
  Download prometheus-client-c...
    -> Subproject exists but has no meson.build file
```

This patch adds a simple meson.build file that fixes the error.